### PR TITLE
fix: pre-release audit fixes

### DIFF
--- a/docs/features/07-vendored-openui5-router-parity.md
+++ b/docs/features/07-vendored-openui5-router-parity.md
@@ -2,6 +2,8 @@
 
 > **Status**: Implemented. The initial vendored parity lane shipped in PR #33.
 > See [docs/reference/upstream-parity.md](../reference/upstream-parity.md) and the [local README](../../packages/lib/test/qunit/upstream-parity/README.md) for the shipped layout and maintenance process.
+>
+> **Implementation note:** The proposal below describes a dedicated CI/test lane. The shipped implementation folded the upstream parity suite into the existing `test:qunit` lane (registered in `testsuite.qunit.ts` and `wdio-qunit.conf.ts`) rather than creating a separate script. The CI workflow file map entry below is historical — no dedicated lane was added.
 
 **Goal:** Add a vendored upstream parity test lane that ports selected public OpenUI5 `sap.m.routing.Router` tests into this repository, runs them against both the native router and `ui5.guard.router.Router`, and proves drop-in compatibility whenever no guards are installed.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -65,28 +65,28 @@ matching, target loading, or event firing occurs.
 |   extends sap.m.routing.Router                                       |
 |   overrides navTo() + parse() to intercept all navigation            |
 |                                                                      |
-|   +--------------------+    +---------------------------+            |
-|   | Guard Management   |    | Navigation Interception   |            |
-|   |                    |    |                           |            |
-|   | addGuard()              |    | navTo() override          |            |
-|   | removeGuard()           |    | parse() override          |            |
-|   | addRouteGuard()         |    | _evaluateGuards()         |            |
-|   | removeRouteGuard()      |    | _applyPreflightDecision() |            |
-|   | addLeaveGuard()         |    | _applyDecision()          |            |
-|   | removeLeaveGuard()      |    | _runLeaveGuards()         |            |
-|   | navigationSettled()     |    | _runEnterGuards()         |            |
-|   | attachNavigationSettled()|    | _runRouteGuards()         |            |
-|   | detachNavigationSettled()|    | _runGuards()              |            |
-|   +-------------------------+    | _cancelPendingNavigation()|            |
-|                             | _continueGuardsAsync()    |            |
-|                             | _validateGuardResult()    |            |
-|                             | _validateLeaveGuardResult()|           |
-|                             | _commitNavigation()       |            |
-|                             | _redirect()               |            |
-|                             | _blockNavigation()        |            |
-|                             | _flushSettlement()        |            |
-|                             | _restoreHash()            |            |
-|                             +---------------------------+            |
+|   +----------------------------+    +-------------------------------+  |
+|   | Guard Management           |    | Navigation Interception       |  |
+|   |                            |    |                               |  |
+|   | addGuard()                 |    | navTo() override              |  |
+|   | removeGuard()              |    | parse() override              |  |
+|   | addRouteGuard()            |    | _evaluateGuards()             |  |
+|   | removeRouteGuard()         |    | _applyPreflightDecision()     |  |
+|   | addLeaveGuard()            |    | _applyDecision()              |  |
+|   | removeLeaveGuard()         |    | _runLeaveGuards()             |  |
+|   | navigationSettled()        |    | _runEnterGuards()             |  |
+|   | attachNavigationSettled()  |    | _runRouteGuards()             |  |
+|   | detachNavigationSettled()  |    | _runGuards()                  |  |
+|   +----------------------------+    | _cancelPendingNavigation()    |  |
+|                                     | _continueGuardsAsync()        |  |
+|                                     | _validateGuardResult()        |  |
+|                                     | _validateLeaveGuardResult()   |  |
+|                                     | _commitNavigation()           |  |
+|                                     | _redirect()                   |  |
+|                                     | _blockNavigation()            |  |
+|                                     | _flushSettlement()            |  |
+|                                     | _restoreHash()                |  |
+|                                     +-------------------------------+  |
 +----------------------------------------------------------------------+
          |
          | super.parse(hash)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"@commitlint/config-conventional": "^20.0.0",
 		"@openui5/types": "1.144.0",
 		"@sapui5/types": "^1.144.0",
+		"@types/mocha": "^10.0.0",
 		"@types/sinon": "^21.0.0",
 		"@wdio/cli": "^9.0.0",
 		"@wdio/local-runner": "^9.0.0",

--- a/packages/demo-app/test/e2e/navto-preflight.e2e.ts
+++ b/packages/demo-app/test/e2e/navto-preflight.e2e.ts
@@ -1,4 +1,3 @@
-import { expect } from "expect";
 import {
 	expectHashToBe,
 	fireEvent,

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -79,7 +79,7 @@ No transpile tooling, no middleware, no additional `ui5.yaml` changes.
 
 #### Option B: Transpile from source
 
-If you prefer to serve from TypeScript sources (e.g. for debugging with source maps), install [`ui5-tooling-transpile`](https://github.com/nicholasmackey/ui5-tooling-transpile) and enable `transpileDependencies` in your app's `ui5.yaml`:
+If you prefer to serve from TypeScript sources (e.g. for debugging with source maps), install [`ui5-tooling-transpile`](https://github.com/ui5-community/ui5-ecosystem-showcase/tree/main/packages/ui5-tooling-transpile) and enable `transpileDependencies` in your app's `ui5.yaml`:
 
 ```bash
 npm install -D ui5-tooling-transpile
@@ -99,7 +99,7 @@ This transpiles the library's `.ts` sources on the fly during `ui5 serve`.
 
 #### Option C: Static serving (workaround)
 
-If neither option works for your setup, you can mount the pre-built resources manually using [`ui5-middleware-servestatic`](https://github.com/nicholasmackey/ui5-middleware-servestatic) (or a similar community middleware) and point it at the `dist/resources` folder in `node_modules`:
+If neither option works for your setup, you can mount the pre-built resources manually using [`ui5-middleware-servestatic`](https://github.com/ui5-community/ui5-ecosystem-showcase/tree/main/packages/ui5-middleware-servestatic) (or a similar community middleware) and point it at the `dist/resources` folder in `node_modules`:
 
 ```bash
 npm install -D ui5-middleware-servestatic
@@ -386,7 +386,7 @@ The demo app keeps `createRedirectWithParamsGuard()` as a reference implementati
 
 ### Guard factories
 
-The demo app keeps matching reusable guard factories in `packages/demo-app/webapp/guards.ts`, including `createAuthGuard()` and `createDirtyFormGuard()`.
+The demo app keeps reusable guard factories in `packages/demo-app/webapp/guards.ts`. `createDirtyFormGuard()` is actively registered as a leave guard on the `"protected"` route; `createAuthGuard()` is a reference-only synchronous alternative to the async `createAsyncPermissionGuard()` used by the demo.
 
 ```typescript
 // guards.ts

--- a/packages/lib/src/Router.ts
+++ b/packages/lib/src/Router.ts
@@ -412,6 +412,9 @@ export default class Router extends MobileRouter implements GuardRouter {
 		const route = this.getRoute(routeName);
 		if (!route) {
 			// Unknown route -- let parent handle it (may fire bypassed event).
+			// Cancel any pending async navigation so settlement resolvers drain
+			// and the stale pipeline does not commit a superseded navigation.
+			this._cancelPendingNavigation();
 			super.navTo(routeName, parameters, componentTargetInfo, replace);
 			return this;
 		}

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -208,12 +208,22 @@ export interface GuardRouter extends MobileRouter {
 	 * a {@link NavigationResult} payload. Unlike the one-shot
 	 * `navigationSettled()` Promise, this event fires for every
 	 * navigation outcome without re-registration.
+	 *
+	 * @param oData - Application-specific payload passed to the handler as second argument.
+	 * @param fnFunction - The function to be called when the event occurs.
+	 * @param oListener - Context object to call the event handler with. Defaults to this Router.
 	 */
 	attachNavigationSettled(
 		oData: object,
 		fnFunction: (evt: Router$NavigationSettledEvent) => void,
 		oListener?: object,
 	): GuardRouter;
+	/**
+	 * Attach an event handler for the `navigationSettled` event (without custom data).
+	 *
+	 * @param fnFunction - The function to be called when the event occurs.
+	 * @param oListener - Context object to call the event handler with. Defaults to this Router.
+	 */
 	attachNavigationSettled(fnFunction: (evt: Router$NavigationSettledEvent) => void, oListener?: object): GuardRouter;
 	/**
 	 * Detach a previously attached `navigationSettled` event handler.

--- a/packages/lib/test/qunit/Router.qunit.ts
+++ b/packages/lib/test/qunit/Router.qunit.ts
@@ -3401,6 +3401,65 @@ QUnit.test("navTo to unknown route falls through to parent without error", funct
 	assert.ok(true, "navTo to unknown route did not throw");
 });
 
+QUnit.test("navTo to unknown route cancels pending async guard pipeline", async function (assert) {
+	let resolveGuard!: (value: boolean) => void;
+	router.addGuard(
+		() =>
+			new Promise<boolean>((r) => {
+				resolveGuard = r;
+			}),
+	);
+	router.initialize();
+
+	// Start an async preflight to a guarded route.
+	router.navTo("protected");
+	const settled = router.navigationSettled();
+
+	// While the async guard is pending, navTo to an unknown route.
+	// This must cancel the pending navigation so settlement resolvers drain.
+	router.navTo("nonexistent");
+
+	// Resolve the now-stale guard to prove it is discarded.
+	resolveGuard(true);
+
+	const result = await settled;
+	assert.strictEqual(
+		result.status,
+		NavigationOutcome.Cancelled,
+		"Pending navigation cancelled when unknown-route navTo supersedes it",
+	);
+});
+
+QUnit.test("navTo to unknown route then real route works after cancellation", async function (assert) {
+	let resolveGuard!: (value: boolean) => void;
+	router.addGuard((context) => {
+		if (context.toRoute === "forbidden") {
+			return true;
+		}
+		return new Promise<boolean>((r) => {
+			resolveGuard = r;
+		});
+	});
+	router.initialize();
+
+	// Start async preflight.
+	router.navTo("protected");
+	const firstSettled = router.navigationSettled();
+
+	// Unknown route supersedes.
+	router.navTo("nonexistent");
+	resolveGuard(true);
+
+	const cancelResult = await firstSettled;
+	assert.strictEqual(cancelResult.status, NavigationOutcome.Cancelled, "First navigation cancelled");
+
+	// Subsequent navTo to a real route must work normally.
+	router.navTo("forbidden");
+	const secondResult = await router.navigationSettled();
+	assert.strictEqual(secondResult.status, NavigationOutcome.Committed, "Subsequent navigation commits");
+	assert.strictEqual(secondResult.route, "forbidden", "Landed on forbidden");
+});
+
 QUnit.test("async preflight superseded by second navTo cancels first", async function (assert) {
 	let resolveGuard!: (value: boolean) => void;
 	router.addGuard(


### PR DESCRIPTION
## Summary

- **Bug fix:** `navTo()` to an unknown route now cancels any pending async guard pipeline. Previously the in-flight pipeline would remain live, leaving `navigationSettled()` resolvers stuck and potentially committing a stale navigation.
- **TDD:** Two new QUnit tests cover the cancellation and verify subsequent navigations work correctly after it.
- **E2E consistency:** Remove stale explicit `import { expect } from "expect"` in `navto-preflight.e2e.ts` to match the global-expect convention used by all other E2E files.
- **Broken links:** Fix GitHub URLs for `ui5-tooling-transpile` and `ui5-middleware-servestatic` (pointed to wrong org `nicholasmackey`, now `ui5-community/ui5-ecosystem-showcase`).
- **README accuracy:** Clarify that `createDirtyFormGuard()` is actively registered in the demo app, while `createAuthGuard()` is reference-only.
- **Docs:** Fix architecture ASCII diagram box alignment; add implementation note to feature doc 07 clarifying the parity suite was folded into `test:qunit`.
- **Types:** Add `@param` JSDoc tags to both `attachNavigationSettled` overloads in `GuardRouter` interface.
- **Dependencies:** Add `@types/mocha` as explicit devDependency (was transitive-only via `@wdio/mocha-framework`).

## Test plan

- [x] New QUnit tests fail before fix, pass after
- [x] Full QUnit suite passes (240 tests)
- [x] `npm run check` passes (format, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)